### PR TITLE
Fix crate compilation on stable, port to edition 2018

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -2,28 +2,24 @@
 rustflags = [
   "-C", "link-arg=-Tlink.x",
   "-C", "linker=arm-none-eabi-ld",
-  "-Z", "linker-flavor=ld",
 ]
 
 [target.thumbv7m-none-eabi]
 rustflags = [
   "-C", "link-arg=-Tlink.x",
   "-C", "linker=arm-none-eabi-ld",
-  "-Z", "linker-flavor=ld",
 ]
 
 [target.thumbv7em-none-eabi]
 rustflags = [
   "-C", "link-arg=-Tlink.x",
   "-C", "linker=arm-none-eabi-ld",
-  "-Z", "linker-flavor=ld",
 ]
 
 [target.thumbv7em-none-eabihf]
 rustflags = [
   "-C", "link-arg=-Tlink.x",
   "-C", "linker=arm-none-eabi-ld",
-  "-Z", "linker-flavor=ld",
 ]
 [build]
 target = "thumbv7em-none-eabihf"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,4 +14,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
  - CAN MessageBufferCode is converted with `decode` instead of `from` since the conversion is fallible
  - Use FIFO buffer when receiving LPUART
  - Updated s32k144 version
+ - Ported crate to stable release channel, Rust edition 2018
+ - Removed deprecated default feature `abort-on-panic` from `cortex-m-rt`; use `extern crate panic_halt;` or use a panic handler in `src/panic.rs` (default: `panic-over-serial`)
 ### Removed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,5 +36,4 @@ lto = true
 default = ["panic-over-serial"]
 itm = []
 panic-over-itm = ["itm"]
-#abort-on-panic = ["cortex-m-rt/abort-on-panic"]
 panic-over-serial = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,6 @@ cortex-m = "0.5.8"
 cortex-m-rt = "0.6.7"
 bit_field = "0.9.0"
 embedded_types = "0.3.2"
-panic-halt = "0.2.0"
 
 [dependencies.s32k144]
 version = "0.10.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-authors = ["Kjetil Kjeka <kjetilkjeka@gmail.com>"]
+authors = ["Kjetil Kjeka <kjetilkjeka@gmail.com>", "Tmplt <tmplt@dragons.rocks>"]
 categories = ["embedded", "no-std", "hardware-support"]
 repository = "https://github.com/kjetilkjeka/s32k144evb.rs"
 description = "Board support crate for s32k144evb"
@@ -12,6 +12,7 @@ version = "0.6.1"
 cortex-m = "0.5.8"
 bit_field = "0.9.0"
 embedded_types = "0.3.2"
+panic-halt = "0.2.0"
 
 [dependencies.cortex-m-rt]
 version = "0.6.7"
@@ -27,7 +28,6 @@ cortex-m-rtfm = "0.4.0"
 [profile.dev]
 opt-level = 0
 debug = true
-lto = true
 
 [profile.release]
 debug = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,20 +10,18 @@ version = "0.6.1"
 
 [dependencies]
 cortex-m = "0.5.8"
+cortex-m-rt = "0.6.7"
 bit_field = "0.9.0"
 embedded_types = "0.3.2"
 panic-halt = "0.2.0"
-
-[dependencies.cortex-m-rt]
-version = "0.6.7"
-default-features = false
 
 [dependencies.s32k144]
 version = "0.10.0"
 features = ["rt"]
 
-[dev-dependencies]
-cortex-m-rtfm = "0.4.0"
+[dev-dependencies.cortex-m-rtfm]
+version = "0.4.0"
+features = ["timer-queue"]
 
 [profile.dev]
 opt-level = 0
@@ -39,3 +37,19 @@ itm = []
 panic-over-itm = ["itm"]
 #abort-on-panic = ["cortex-m-rt/abort-on-panic"]
 panic-over-serial = []
+
+[[example]]
+name = "rtfm"
+edition = "2018"
+
+[[example]]
+name = "can"
+edition = "2015"
+
+[[example]]
+name = "led"
+edition = "2015"
+
+[[example]]
+name = "serial"
+edition = "2015"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,20 +9,20 @@ name = "s32k144evb"
 version = "0.6.1"
 
 [dependencies]
-cortex-m = "0.4.3"
+cortex-m = "0.5.8"
 bit_field = "0.9.0"
 embedded_types = "0.3.2"
 
 [dependencies.cortex-m-rt]
-version = "0.3.6"
+version = "0.6.7"
 default-features = false
 
 [dependencies.s32k144]
-version = "0.9"
+version = "0.10.0"
 features = ["rt"]
 
 [dev-dependencies]
-cortex-m-rtfm = "0.3.1"
+cortex-m-rtfm = "0.4.0"
 
 [profile.dev]
 opt-level = 0
@@ -37,5 +37,5 @@ lto = true
 default = ["panic-over-serial"]
 itm = []
 panic-over-itm = ["itm"]
-abort-on-panic = ["cortex-m-rt/abort-on-panic"]
+#abort-on-panic = ["cortex-m-rt/abort-on-panic"]
 panic-over-serial = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ keywords = ["arm", "cortex-m", "s32k144", "template"]
 license = "MIT OR Apache-2.0"
 name = "s32k144evb"
 version = "0.6.1"
+edition = "2018"
 
 [dependencies]
 cortex-m = "0.5.8"
@@ -37,19 +38,3 @@ itm = []
 panic-over-itm = ["itm"]
 #abort-on-panic = ["cortex-m-rt/abort-on-panic"]
 panic-over-serial = []
-
-[[example]]
-name = "rtfm"
-edition = "2018"
-
-[[example]]
-name = "can"
-edition = "2015"
-
-[[example]]
-name = "led"
-edition = "2015"
-
-[[example]]
-name = "serial"
-edition = "2015"

--- a/examples/can.rs
+++ b/examples/can.rs
@@ -3,7 +3,6 @@
 
 extern crate cortex_m_rt;
 extern crate embedded_types;
-extern crate panic_halt;
 extern crate s32k144;
 extern crate s32k144evb;
 

--- a/examples/can.rs
+++ b/examples/can.rs
@@ -1,23 +1,24 @@
-#![feature(used)]
+#![no_main]
 #![no_std]
 
-#[macro_use]
-extern crate cortex_m;
+extern crate cortex_m_rt;
 extern crate embedded_types;
+extern crate panic_halt;
 extern crate s32k144;
 extern crate s32k144evb;
 
-use cortex_m::asm;
+use cortex_m_rt::entry;
 
 use s32k144evb::{can, spc, wdog};
 
-use s32k144evb::pcc::{self, Pcc};
+use s32k144evb::pcc::Pcc;
 
 use s32k144evb::can::{CanSettings, ID};
 
 use embedded_types::can::{BaseID, DataFrame};
 
-fn main() {
+#[entry]
+fn main() -> ! {
     let peripherals = s32k144::Peripherals::take().unwrap();
 
     let wdog_settings = wdog::WatchdogSettings {

--- a/examples/led.rs
+++ b/examples/led.rs
@@ -3,41 +3,30 @@
 
 #[macro_use]
 extern crate cortex_m;
-extern crate s32k144evb;
 extern crate s32k144;
+extern crate s32k144evb;
 
-use s32k144evb::{
-    led,
-    wdog,
-};
+use s32k144evb::{led, wdog};
 
 use s32k144evb::pcc::Pcc;
 
-
 fn main() {
-
     let peripherals = s32k144::Peripherals::take().unwrap();
-    
+
     let mut wdog_settings = wdog::WatchdogSettings::default();
     wdog_settings.enable = false;
     let _wdog = wdog::Watchdog::init(&peripherals.WDOG, wdog_settings);
 
     let pcc = Pcc::init(&peripherals.PCC);
     let pcc_portd = pcc.enable_portd().unwrap();
-    
-    let led = led::RgbLed::init(
-        &peripherals.PTD,
-        &peripherals.PORTD,
-        &pcc_portd,
-    );
+
+    let led = led::RgbLed::init(&peripherals.PTD, &peripherals.PORTD, &pcc_portd);
 
     loop {
-        
         let loop_max = 3000;
-        
-        for i in 0..8*loop_max {
-        
-            match i/loop_max {
+
+        for i in 0..8 * loop_max {
+            match i / loop_max {
                 0 => led.set(false, false, false),
                 1 => led.set(false, false, true),
                 2 => led.set(false, true, false),
@@ -48,9 +37,6 @@ fn main() {
                 7 => led.set(true, true, true),
                 _ => unreachable!(),
             }
-            
-        
         }
     }
-    
 }

--- a/examples/led.rs
+++ b/examples/led.rs
@@ -2,7 +2,6 @@
 #![no_std]
 
 extern crate cortex_m_rt;
-extern crate panic_halt;
 extern crate s32k144;
 extern crate s32k144evb;
 

--- a/examples/led.rs
+++ b/examples/led.rs
@@ -1,16 +1,19 @@
-#![feature(used)]
+#![no_main]
 #![no_std]
 
-#[macro_use]
-extern crate cortex_m;
+extern crate cortex_m_rt;
+extern crate panic_halt;
 extern crate s32k144;
 extern crate s32k144evb;
+
+use cortex_m_rt::entry;
 
 use s32k144evb::{led, wdog};
 
 use s32k144evb::pcc::Pcc;
 
-fn main() {
+#[entry]
+fn main() -> ! {
     let peripherals = s32k144::Peripherals::take().unwrap();
 
     let mut wdog_settings = wdog::WatchdogSettings::default();

--- a/examples/rtfm.rs
+++ b/examples/rtfm.rs
@@ -1,69 +1,71 @@
-#![feature(used)]
-#![feature(proc_macro)]
+//! Periodical toggling of the green LED using RTFM.
+//!
+//! s32k144evb::led::RgbLed cannot safely be shared yet, hence the unsafe code.
+
+#![no_main]
 #![no_std]
 
 extern crate cortex_m;
-extern crate cortex_m_rtfm as rtfm;
+extern crate panic_halt;
 extern crate s32k144;
 extern crate s32k144evb;
 
-use cortex_m::peripheral::SystClkSource;
-
-use rtfm::{app, Threshold};
-
 use s32k144::Interrupt;
-use s32k144evb::{led, wdog};
 
-app! {
-    device: s32k144,
+use rtfm::{app, Instant};
 
-    resources: {
-        static ON: bool = false;
-        static COUNT: u32 = 0;
-    },
+use s32k144evb::{led, pcc, wdog};
 
-    tasks: {
-        SYS_TICK: {
-            path: toggle,
-            resources: [ON, COUNT],
-        },
-    },
-}
+const PERIOD: u32 = 16_000_000;
 
-fn init(p: init::Peripherals, _r: init::Resources) {
-    let mut wdog_settings = wdog::WatchdogSettings::default();
-    wdog_settings.enable = false;
-    let _wdog = wdog::Watchdog::init(p.WDOG, wdog_settings);
+#[app(device = s32k144)]
+const APP: () = {
+    // Resources
+    static mut ON: bool = false;
+    static mut PTD: s32k144::PTD = ();
 
-    led::init();
-    led::RED.off();
-    led::GREEN.off();
-    led::BLUE.off();
+    #[init(schedule = [toggle])]
+    fn init() {
+        let mut wdog_settings = wdog::WatchdogSettings::default();
+        wdog_settings.enable = false;
+        let _wdog = wdog::Watchdog::init(&device.WDOG, wdog_settings);
 
-    p.SYST.set_clock_source(SystClkSource::Core);
-    p.SYST.set_reload(400_000); // Frequency 100Hz
-    p.SYST.enable_interrupt();
-    p.SYST.enable_counter();
-}
+        let pcc = pcc::Pcc::init(&device.PCC);
+        let pcc_portd = pcc.enable_portd().unwrap();
 
-fn idle() -> ! {
-    // Sleep
-    loop {
-        rtfm::wfi();
+        let led = led::RgbLed::init(&device.PTD, &device.PORTD, &pcc_portd);
+        led.set(false, false, false);
+
+        schedule.toggle(Instant::now() + PERIOD.cycles()).unwrap();
+
+        PTD = device.PTD;
     }
-}
 
-fn toggle(_t: &mut Threshold, r: SYS_TICK::Resources) {
-    **r.COUNT += 1;
-
-    if **r.COUNT >= 100 {
-        //1s
-        **r.COUNT = 0;
-        **r.ON = !**r.ON;
-        if **r.ON {
-            led::GREEN.on();
-        } else {
-            led::GREEN.off();
+    #[idle]
+    fn idle() -> ! {
+        // Sleep
+        loop {
+            rtfm::pend(Interrupt::DMA0);
         }
     }
-}
+
+    #[task(resources = [ON, PTD], schedule = [toggle])]
+    fn toggle() {
+        let r = resources;
+
+        if *r.ON {
+            r.PTD.pcor.write(|w| unsafe { w.ptco().bits(1 << 16) });
+        } else {
+            r.PTD.psor.write(|w| unsafe { w.ptso().bits(1 << 16) });
+        }
+
+        *r.ON = !(*r.ON);
+
+        schedule.toggle(scheduled + PERIOD.cycles()).unwrap();
+    }
+
+    // Interrupt handlers used to dispatch software tasks
+    extern "C" {
+        fn DMA0();
+    }
+};

--- a/examples/rtfm.rs
+++ b/examples/rtfm.rs
@@ -3,20 +3,16 @@
 #![no_std]
 
 extern crate cortex_m;
+extern crate cortex_m_rtfm as rtfm;
 extern crate s32k144;
 extern crate s32k144evb;
-extern crate cortex_m_rtfm as rtfm;
 
 use cortex_m::peripheral::SystClkSource;
 
 use rtfm::{app, Threshold};
 
-use s32k144evb::{
-    led,
-    wdog,
-};
 use s32k144::Interrupt;
-
+use s32k144evb::{led, wdog};
 
 app! {
     device: s32k144,
@@ -25,7 +21,7 @@ app! {
         static ON: bool = false;
         static COUNT: u32 = 0;
     },
-    
+
     tasks: {
         SYS_TICK: {
             path: toggle,
@@ -34,13 +30,11 @@ app! {
     },
 }
 
-
 fn init(p: init::Peripherals, _r: init::Resources) {
-
     let mut wdog_settings = wdog::WatchdogSettings::default();
     wdog_settings.enable = false;
     let _wdog = wdog::Watchdog::init(p.WDOG, wdog_settings);
-    
+
     led::init();
     led::RED.off();
     led::GREEN.off();
@@ -62,7 +56,8 @@ fn idle() -> ! {
 fn toggle(_t: &mut Threshold, r: SYS_TICK::Resources) {
     **r.COUNT += 1;
 
-    if **r.COUNT >= 100 { //1s
+    if **r.COUNT >= 100 {
+        //1s
         **r.COUNT = 0;
         **r.ON = !**r.ON;
         if **r.ON {

--- a/examples/rtfm.rs
+++ b/examples/rtfm.rs
@@ -6,7 +6,6 @@
 #![no_std]
 
 extern crate cortex_m;
-extern crate panic_halt;
 extern crate s32k144;
 extern crate s32k144evb;
 

--- a/examples/serial.rs
+++ b/examples/serial.rs
@@ -1,11 +1,13 @@
-#![feature(used)]
+#![no_main]
 #![no_std]
 
-extern crate cortex_m;
-extern crate s32k144;
-#[macro_use]
-extern crate s32k144evb;
+extern crate cortex_m_rt;
 extern crate embedded_types;
+extern crate panic_halt;
+extern crate s32k144;
+extern crate s32k144evb;
+
+use cortex_m_rt::entry;
 
 use embedded_types::io::Read;
 use embedded_types::io::Write;
@@ -14,7 +16,8 @@ use s32k144evb::{spc, wdog};
 
 use s32k144evb::pcc::{self, Pcc};
 
-fn main() {
+#[entry]
+fn main() -> ! {
     let peripherals = s32k144::Peripherals::take().unwrap();
 
     let mut wdog_settings = wdog::WatchdogSettings::default();

--- a/examples/serial.rs
+++ b/examples/serial.rs
@@ -3,7 +3,6 @@
 
 extern crate cortex_m_rt;
 extern crate embedded_types;
-extern crate panic_halt;
 extern crate s32k144;
 extern crate s32k144evb;
 

--- a/examples/serial.rs
+++ b/examples/serial.rs
@@ -7,18 +7,12 @@ extern crate s32k144;
 extern crate s32k144evb;
 extern crate embedded_types;
 
-use embedded_types::io::Write;
 use embedded_types::io::Read;
+use embedded_types::io::Write;
 
-use s32k144evb::{
-    wdog,
-    spc,
-};
+use s32k144evb::{spc, wdog};
 
-use s32k144evb::pcc::{
-    self,
-    Pcc,
-};
+use s32k144evb::pcc::{self, Pcc};
 
 fn main() {
     let peripherals = s32k144::Peripherals::take().unwrap();
@@ -26,39 +20,47 @@ fn main() {
     let mut wdog_settings = wdog::WatchdogSettings::default();
     wdog_settings.enable = false;
     let _wdog = wdog::Watchdog::init(&peripherals.WDOG, wdog_settings);
-    
-    let pc_config = spc::Config{
+
+    let pc_config = spc::Config {
         system_oscillator: spc::SystemOscillatorInput::Crystal(8_000_000),
         soscdiv2: spc::SystemOscillatorOutput::Div1,
-        .. Default::default()
+        ..Default::default()
     };
-    
+
     let spc = spc::Spc::init(
         &peripherals.SCG,
         &peripherals.SMC,
         &peripherals.PMC,
-        pc_config
-    ).unwrap();
-    
+        pc_config,
+    )
+    .unwrap();
 
     let pcc = Pcc::init(&peripherals.PCC);
     let _pcc_lpuart1 = pcc.enable_lpuart1(pcc::ClockSource::Soscdiv2).unwrap();
     let _pcc_portc = pcc.enable_portc().unwrap();
-    
+
     let portc = peripherals.PORTC;
     portc.pcr6.modify(|_, w| w.mux()._010());
     portc.pcr7.modify(|_, w| w.mux()._010());
 
-    
     let mut console = s32k144evb::console::LpuartConsole::init(&peripherals.LPUART1, &spc);
 
     writeln!(console, "Please write something").unwrap();
     let mut buf = [0u8; 64];
     let chars = console.read_until(b'\n', &mut buf).unwrap();
 
-    writeln!(console, "Your wrote: \"{}\"", core::str::from_utf8(&buf[0..chars]).unwrap()).unwrap();
-    
-    writeln!(console, "Next a panic will be demonstrated by overflowing an integer").unwrap();
+    writeln!(
+        console,
+        "Your wrote: \"{}\"",
+        core::str::from_utf8(&buf[0..chars]).unwrap()
+    )
+    .unwrap();
+
+    writeln!(
+        console,
+        "Next a panic will be demonstrated by overflowing an integer"
+    )
+    .unwrap();
     let mut i: u8 = 0;
 
     loop {

--- a/src/can.rs
+++ b/src/can.rs
@@ -5,18 +5,11 @@ use s32k144::can0;
 
 use spc;
 
-pub use embedded_types::can::{
-    ID,
-    CanFrame,
-};
+pub use embedded_types::can::{CanFrame, ID};
 
 use embedded_types;
 
-use embedded_types::can::{
-    ExtendedID,
-    BaseID,
-    ExtendedDataFrame,
-};
+use embedded_types::can::{BaseID, ExtendedDataFrame, ExtendedID};
 
 use embedded_types::io::Error as IOError;
 
@@ -29,82 +22,92 @@ pub struct Can<'a> {
 }
 
 impl<'a> Can<'a> {
-    pub fn init(can: &'a s32k144::can0::RegisterBlock,
-                spc: &'a spc::Spc<'a>,
-                settings: &CanSettings,
+    pub fn init(
+        can: &'a s32k144::can0::RegisterBlock,
+        spc: &'a spc::Spc<'a>,
+        settings: &CanSettings,
     ) -> Result<Self, CanError> {
-
         let source_frequency = {
             match settings.clock_source {
                 ClockSource::Sys => spc.core_freq(),
-                ClockSource::Soscdiv2 => spc.soscdiv2_freq().ok_or(CanError::ClockSourceDisabled)?,
+                ClockSource::Soscdiv2 => {
+                    spc.soscdiv2_freq().ok_or(CanError::ClockSourceDisabled)?
+                }
             }
         };
-                
+
         if source_frequency % settings.can_frequency != 0 {
             return Err(CanError::SettingsError);
         }
-        
-        if source_frequency < settings.can_frequency*5 {
+
+        if source_frequency < settings.can_frequency * 5 {
             return Err(CanError::SettingsError);
         }
 
         // TODO: check if message_buffer_settings are longer than max MB available
-        
+
         let presdiv = (source_frequency / settings.can_frequency) / 25;
-        let tqs = ( source_frequency / (presdiv + 1) ) / settings.can_frequency;
+        let tqs = (source_frequency / (presdiv + 1)) / settings.can_frequency;
 
         // Table 50-26 in datasheet, can standard compliant settings
-        let (pseg2, rjw) =
-            if tqs >= 8 && tqs < 10 {
-                (1, 1)
-            } else if tqs >= 10 && tqs < 15 {
-                (3, 2)
-            } else if tqs >= 15 && tqs < 20 {
-                (6, 2)
-            } else if tqs >= 20 && tqs < 26 {
-                (7, 3)
-            } else {
-                panic!("there should be between 8 and 25 tqs in an bit");
-            };
-        
-        let pseg1 = ( (tqs - (pseg2 + 1) ) / 2 ) - 1;
-        let propseg = tqs - (pseg2 + 1) - (pseg1 + 1) - 2;
-        
+        let (pseg2, rjw) = if tqs >= 8 && tqs < 10 {
+            (1, 1)
+        } else if tqs >= 10 && tqs < 15 {
+            (3, 2)
+        } else if tqs >= 15 && tqs < 20 {
+            (6, 2)
+        } else if tqs >= 20 && tqs < 26 {
+            (7, 3)
+        } else {
+            panic!("there should be between 8 and 25 tqs in an bit");
+        };
 
+        let pseg1 = ((tqs - (pseg2 + 1)) / 2) - 1;
+        let propseg = tqs - (pseg2 + 1) - (pseg1 + 1) - 2;
 
         reset(can);
 
         // first set clock source
-        can.ctrl1.modify(|_, w| w.clksrc().bit(settings.clock_source == ClockSource::Sys));
-        
+        can.ctrl1
+            .modify(|_, w| w.clksrc().bit(settings.clock_source == ClockSource::Sys));
+
         enable(can);
         enter_freeze(can);
-        
-        
-        can.mcr.modify(|_, w| { w
-                                .rfen().bit(false)
-                                .srxdis().bit(!settings.self_reception)
-                                .irmq().bit(settings.individual_masking)
-                                .aen().bit(true)
-                                .dma().bit(false);
-                                unsafe { w.maxmb().bits((RX_MAILBOXES+TX_MAILBOXES) as u8-1) };
-                                w
+
+        can.mcr.modify(|_, w| {
+            w.rfen()
+                .bit(false)
+                .srxdis()
+                .bit(!settings.self_reception)
+                .irmq()
+                .bit(settings.individual_masking)
+                .aen()
+                .bit(true)
+                .dma()
+                .bit(false);
+            unsafe { w.maxmb().bits((RX_MAILBOXES + TX_MAILBOXES) as u8 - 1) };
+            w
         });
-            
-        can.ctrl1.modify(|_, w| { unsafe { w
-                                           .presdiv().bits(presdiv as u8)
-                                           .pseg1().bits(pseg1 as u8)
-                                           .pseg2().bits(pseg2 as u8)
-                                           .propseg().bits(propseg as u8)
-                                           .rjw().bits(rjw as u8)
-                                           .lpb().bit(settings.loopback_mode)                                
-        }});
+
+        can.ctrl1.modify(|_, w| unsafe {
+            w.presdiv()
+                .bits(presdiv as u8)
+                .pseg1()
+                .bits(pseg1 as u8)
+                .pseg2()
+                .bits(pseg2 as u8)
+                .propseg()
+                .bits(propseg as u8)
+                .rjw()
+                .bits(rjw as u8)
+                .lpb()
+                .bit(settings.loopback_mode)
+        });
 
         // set filter mask to accept all
         // TODO: Make better logic for setting filters
-        can.rxmgmask.write(unsafe {|w| w.bits(0)});
-        
+        can.rxmgmask.write(unsafe { |w| w.bits(0) });
+
         /*
         • Initialize the Message Buffers
         • The Control and Status word of all Message Buffers must be initialized
@@ -113,29 +116,40 @@ impl<'a> Can<'a> {
          */
 
         let filter_frame = CanFrame::from(ExtendedDataFrame::new(ExtendedID::new(0))); // TODO: set filters better then on extended data frames
-        
+
         for mb in 0..TX_MAILBOXES {
             inactivate_mailbox(can, mb as usize);
-            write_mailbox(can, &MailboxHeader::default_transmit(), &filter_frame, mb as usize).unwrap();
+            write_mailbox(
+                can,
+                &MailboxHeader::default_transmit(),
+                &filter_frame,
+                mb as usize,
+            )
+            .unwrap();
         }
-        
-        for mb in TX_MAILBOXES..(TX_MAILBOXES+RX_MAILBOXES) {
+
+        for mb in TX_MAILBOXES..(TX_MAILBOXES + RX_MAILBOXES) {
             inactivate_mailbox(can, mb as usize);
-            write_mailbox(can, &MailboxHeader::default_receive(), &filter_frame, mb as usize).unwrap();
+            write_mailbox(
+                can,
+                &MailboxHeader::default_receive(),
+                &filter_frame,
+                mb as usize,
+            )
+            .unwrap();
         }
 
         // clear all interrupt flags so data wont dangle
-        can.iflag1.write(|w| unsafe{w.bits(0xffff_ffff)});
-        
+        can.iflag1.write(|w| unsafe { w.bits(0xffff_ffff) });
+
         leave_freeze(can);
-        
+
         // Make some acceptance test to see if the configurations have been applied
-        
-        return Ok(Can{
+
+        return Ok(Can {
             register_block: can,
             _spc: spc,
         });
-        
     }
 
     /// Does not attempt to swap frames if all mailboxes are full, not suitable for frames
@@ -145,7 +159,9 @@ impl<'a> Can<'a> {
         header.code = MessageBufferCode::Transmit(TransmitBufferState::DataRemote);
 
         for i in 0..TX_MAILBOXES {
-            if read_mailbox_code(self.register_block, i) == MessageBufferCode::Transmit(TransmitBufferState::Inactive) {
+            if read_mailbox_code(self.register_block, i)
+                == MessageBufferCode::Transmit(TransmitBufferState::Inactive)
+            {
                 match write_mailbox(self.register_block, &header, frame, i) {
                     Ok(()) => return Ok(()),
                     Err(_) => (),
@@ -159,23 +175,23 @@ impl<'a> Can<'a> {
     pub fn transmit(&self, frame: &CanFrame) -> Result<Option<CanFrame>, IOError> {
         let mut highest_id = 0;
         let mut mailbox_number = usize::max_value();
-        
+
         let mut transmit_header = MailboxHeader::default_transmit();
         transmit_header.code = MessageBufferCode::Transmit(TransmitBufferState::DataRemote);
-        
+
         for i in 0..TX_MAILBOXES {
             let (header, old_frame) = read_mailbox(self.register_block, i);
             match header.code {
                 MessageBufferCode::Transmit(TransmitBufferState::Inactive) => {
                     write_mailbox(self.register_block, &transmit_header, frame, i).unwrap();
                     return Ok(None);
-                },
+                }
                 MessageBufferCode::Transmit(TransmitBufferState::DataRemote) => {
                     if u32::from(old_frame.id()) > highest_id {
                         highest_id = u32::from(frame.id());
                         mailbox_number = i;
                     }
-                },
+                }
                 _ => unreachable!(),
             }
         }
@@ -186,23 +202,22 @@ impl<'a> Can<'a> {
             Ok(aborted_frame)
         } else {
             Err(IOError::BufferExhausted)
-        }        
+        }
     }
-    
+
     pub fn receive(&self) -> Result<CanFrame, IOError> {
-        for i in TX_MAILBOXES..(TX_MAILBOXES+RX_MAILBOXES) {
+        for i in TX_MAILBOXES..(TX_MAILBOXES + RX_MAILBOXES) {
             let new_message = self.register_block.iflag1.read().bits().get_bit(i);
             if new_message {
                 let (_header, frame) = read_mailbox(self.register_block, i);
                 return Ok(frame);
             }
-        }           
+        }
         Err(IOError::BufferExhausted)
-    }    
+    }
 }
-    
-pub struct CanSettings {
 
+pub struct CanSettings {
     /// When asserted, this bit enables the generation of the TWRNINT and RWRNINT flags in the Error and
     /// Status Register 1 (ESR1). If WRNEN is negated, the TWRNINT and RWRNINT flags will always be zero,
     /// independent of the values of the error counters, and no warning interrupt will ever be generated. This bit
@@ -219,7 +234,7 @@ pub struct CanSettings {
     /// on masking scheme with CAN_RXMGMASK, CAN_RX14MASK, CAN_RX15MASK and
     /// CAN_RXFGMASK.
     pub individual_masking: bool,
-    
+
     /// This bit configures FlexCAN to operate in Loop-Back mode. In this mode, FlexCAN performs an internal
     /// loop back that can be used for self test operation. The bit stream output of the transmitter is fed back
     /// internally to the receiver input. The Rx CAN input pin is ignored and the Tx CAN output goes to the
@@ -233,12 +248,11 @@ pub struct CanSettings {
     pub clock_source: ClockSource,
 
     pub can_frequency: u32,
-    
 }
 
 impl Default for CanSettings {
     fn default() -> Self {
-        CanSettings{
+        CanSettings {
             warning_interrupt: false,
             self_reception: true,
             individual_masking: false,
@@ -265,8 +279,8 @@ impl Default for ClockSource {
     fn default() -> Self {
         ClockSource::Soscdiv2
     }
-}    
- 
+}
+
 #[derive(Clone, PartialEq)]
 enum MessageBufferCode {
     Receive(ReceiveBufferCode),
@@ -317,17 +331,27 @@ impl From<MessageBufferCode> for u8 {
     fn from(code: MessageBufferCode) -> u8 {
         match code {
             MessageBufferCode::Receive(ref r) => match r.state {
-                ReceiveBufferState::Inactive => 0u8.set_bit(0, r.busy).set_bits(1..4, 0b000).get_bits(0..4),
-                ReceiveBufferState::Empty => 0u8.set_bit(0, r.busy).set_bits(1..4, 0b010).get_bits(0..4),
-                ReceiveBufferState::Full => 0u8.set_bit(0, r.busy).set_bits(1..4, 0b001).get_bits(0..4),
-                ReceiveBufferState::Overrun => 0u8.set_bit(0, r.busy).set_bits(1..4, 0b011).get_bits(0..4),
-                ReceiveBufferState::Ranswer => 0u8.set_bit(0, r.busy).set_bits(1..4, 0b101).get_bits(0..4),
+                ReceiveBufferState::Inactive => {
+                    0u8.set_bit(0, r.busy).set_bits(1..4, 0b000).get_bits(0..4)
+                }
+                ReceiveBufferState::Empty => {
+                    0u8.set_bit(0, r.busy).set_bits(1..4, 0b010).get_bits(0..4)
+                }
+                ReceiveBufferState::Full => {
+                    0u8.set_bit(0, r.busy).set_bits(1..4, 0b001).get_bits(0..4)
+                }
+                ReceiveBufferState::Overrun => {
+                    0u8.set_bit(0, r.busy).set_bits(1..4, 0b011).get_bits(0..4)
+                }
+                ReceiveBufferState::Ranswer => {
+                    0u8.set_bit(0, r.busy).set_bits(1..4, 0b101).get_bits(0..4)
+                }
             },
             MessageBufferCode::Transmit(ref t) => match *t {
                 TransmitBufferState::Inactive => 0b1000,
                 TransmitBufferState::Abort => 0b1001,
                 TransmitBufferState::DataRemote => 0b1100,
-                TransmitBufferState::Tanswer => 0b1110,    
+                TransmitBufferState::Tanswer => 0b1110,
             },
         }
     }
@@ -340,21 +364,50 @@ impl MessageBufferCode {
             0b1001 => Ok(MessageBufferCode::Transmit(TransmitBufferState::Abort)),
             0b1100 => Ok(MessageBufferCode::Transmit(TransmitBufferState::DataRemote)),
             0b1110 => Ok(MessageBufferCode::Transmit(TransmitBufferState::Tanswer)),
-            0b0000 => Ok(MessageBufferCode::Receive(ReceiveBufferCode{state: ReceiveBufferState::Inactive, busy: false})),
-            0b0001 => Ok(MessageBufferCode::Receive(ReceiveBufferCode{state: ReceiveBufferState::Inactive, busy: true})),
-            0b0100 => Ok(MessageBufferCode::Receive(ReceiveBufferCode{state: ReceiveBufferState::Empty, busy: false})),
-            0b0101 => Ok(MessageBufferCode::Receive(ReceiveBufferCode{state: ReceiveBufferState::Empty, busy: true})),
-            0b0010 => Ok(MessageBufferCode::Receive(ReceiveBufferCode{state: ReceiveBufferState::Full, busy: false})),
-            0b0011 => Ok(MessageBufferCode::Receive(ReceiveBufferCode{state: ReceiveBufferState::Full, busy: true})),
-            0b0110 => Ok(MessageBufferCode::Receive(ReceiveBufferCode{state: ReceiveBufferState::Overrun, busy: false})),
-            0b0111 => Ok(MessageBufferCode::Receive(ReceiveBufferCode{state: ReceiveBufferState::Overrun, busy: true})),
-            0b1010 => Ok(MessageBufferCode::Receive(ReceiveBufferCode{state: ReceiveBufferState::Ranswer, busy: false})),
-            0b1011 => Ok(MessageBufferCode::Receive(ReceiveBufferCode{state: ReceiveBufferState::Ranswer, busy: true})),
+            0b0000 => Ok(MessageBufferCode::Receive(ReceiveBufferCode {
+                state: ReceiveBufferState::Inactive,
+                busy: false,
+            })),
+            0b0001 => Ok(MessageBufferCode::Receive(ReceiveBufferCode {
+                state: ReceiveBufferState::Inactive,
+                busy: true,
+            })),
+            0b0100 => Ok(MessageBufferCode::Receive(ReceiveBufferCode {
+                state: ReceiveBufferState::Empty,
+                busy: false,
+            })),
+            0b0101 => Ok(MessageBufferCode::Receive(ReceiveBufferCode {
+                state: ReceiveBufferState::Empty,
+                busy: true,
+            })),
+            0b0010 => Ok(MessageBufferCode::Receive(ReceiveBufferCode {
+                state: ReceiveBufferState::Full,
+                busy: false,
+            })),
+            0b0011 => Ok(MessageBufferCode::Receive(ReceiveBufferCode {
+                state: ReceiveBufferState::Full,
+                busy: true,
+            })),
+            0b0110 => Ok(MessageBufferCode::Receive(ReceiveBufferCode {
+                state: ReceiveBufferState::Overrun,
+                busy: false,
+            })),
+            0b0111 => Ok(MessageBufferCode::Receive(ReceiveBufferCode {
+                state: ReceiveBufferState::Overrun,
+                busy: true,
+            })),
+            0b1010 => Ok(MessageBufferCode::Receive(ReceiveBufferCode {
+                state: ReceiveBufferState::Ranswer,
+                busy: false,
+            })),
+            0b1011 => Ok(MessageBufferCode::Receive(ReceiveBufferCode {
+                state: ReceiveBufferState::Ranswer,
+                busy: true,
+            })),
             _ => Err(()),
         }
     }
 }
-
 
 struct MailboxHeader {
     /// This bit indicates if the transmitting node is error active or error passive.
@@ -376,7 +429,7 @@ struct MailboxHeader {
 
 impl MailboxHeader {
     pub fn default_transmit() -> Self {
-        MailboxHeader{
+        MailboxHeader {
             error_state_indicator: false,
             code: MessageBufferCode::Transmit(TransmitBufferState::Inactive),
             time_stamp: 0,
@@ -385,15 +438,17 @@ impl MailboxHeader {
     }
 
     pub fn default_receive() -> Self {
-        MailboxHeader{
+        MailboxHeader {
             error_state_indicator: false,
-            code: MessageBufferCode::Receive(ReceiveBufferCode{state: ReceiveBufferState::Empty, busy: false}),
+            code: MessageBufferCode::Receive(ReceiveBufferCode {
+                state: ReceiveBufferState::Empty,
+                busy: false,
+            }),
             time_stamp: 0,
             priority: 0,
         }
     }
 }
-
 
 fn enable(can: &can0::RegisterBlock) {
     can.mcr.modify(|_, w| w.mdis()._0());
@@ -413,20 +468,14 @@ fn reset(can: &can0::RegisterBlock) {
 }
 
 fn enter_freeze(can: &can0::RegisterBlock) {
-    can.mcr.modify(|_, w| w
-                   .frz()._1()
-                   .halt()._1()
-    );
+    can.mcr.modify(|_, w| w.frz()._1().halt()._1());
     while can.mcr.read().frzack().is_0() {}
 }
 
 fn leave_freeze(can: &can0::RegisterBlock) {
-    can.mcr.modify(|_, w| w
-                   .halt()._0()
-                   .frz()._0()
-    );
+    can.mcr.modify(|_, w| w.halt()._0().frz()._0());
     while can.mcr.read().frzack().is_1() {}
-}    
+}
 
 #[derive(Debug)]
 pub enum CanError {
@@ -438,20 +487,40 @@ pub enum CanError {
 }
 
 fn read_mailbox_code(can: &can0::RegisterBlock, mailbox: usize) -> MessageBufferCode {
-    let start_adress = mailbox*4;
-    let code = MessageBufferCode::decode(can.embedded_ram[start_adress].read().bits().get_bits(24..28) as u8).unwrap();
+    let start_adress = mailbox * 4;
+    let code = MessageBufferCode::decode(
+        can.embedded_ram[start_adress]
+            .read()
+            .bits()
+            .get_bits(24..28) as u8,
+    )
+    .unwrap();
     // The read might have caused a lock, need to read the timer to unlock all mailboxes just in case.
-    let _time = can.timer.read(); 
+    let _time = can.timer.read();
     code
 }
 
-fn abort_mailbox(can: &can0::RegisterBlock, mailbox: usize) -> Option<CanFrame>{
+fn abort_mailbox(can: &can0::RegisterBlock, mailbox: usize) -> Option<CanFrame> {
     // TODO: this function is untested, test it (it requires mcr.aen() bit set as well)
-    let start_adress = mailbox*4;
-    if MessageBufferCode::decode(can.embedded_ram[start_adress].read().bits().get_bits(24..28) as u8) == Ok(MessageBufferCode::Transmit(TransmitBufferState::DataRemote)) {
-        can.iflag1.write(|w| unsafe{w.bits(1<<mailbox)} );
-        can.embedded_ram[start_adress].write(|w| unsafe{ w.bits(0u32.set_bits(24..28, u8::from(MessageBufferCode::Transmit(TransmitBufferState::Abort)) as u32).get_bits(0..32))});
-        while can.iflag1.read().bits() & (1<<mailbox) != 0 {}
+    let start_adress = mailbox * 4;
+    if MessageBufferCode::decode(
+        can.embedded_ram[start_adress]
+            .read()
+            .bits()
+            .get_bits(24..28) as u8,
+    ) == Ok(MessageBufferCode::Transmit(TransmitBufferState::DataRemote))
+    {
+        can.iflag1.write(|w| unsafe { w.bits(1 << mailbox) });
+        can.embedded_ram[start_adress].write(|w| unsafe {
+            w.bits(
+                0u32.set_bits(
+                    24..28,
+                    u8::from(MessageBufferCode::Transmit(TransmitBufferState::Abort)) as u32,
+                )
+                .get_bits(0..32),
+            )
+        });
+        while can.iflag1.read().bits() & (1 << mailbox) != 0 {}
         let (header, frame) = read_mailbox(can, mailbox);
 
         match header.code {
@@ -472,11 +541,35 @@ fn abort_mailbox(can: &can0::RegisterBlock, mailbox: usize) -> Option<CanFrame>{
 ///  - A frame containing the message within the inactivated Tx Mailbox may be transmitted without setting the respective IFLAG
 fn inactivate_mailbox(can: &can0::RegisterBlock, mailbox: usize) {
     //TODO: consider clearing interrupt
-    let start_adress = mailbox*4;
-    match MessageBufferCode::decode(can.embedded_ram[start_adress].read().bits().get_bits(24..28) as u8) {
-        Ok(MessageBufferCode::Transmit(_)) => can.embedded_ram[start_adress].write(|w| unsafe{ w.bits(0u32.set_bits(24..28, u8::from(MessageBufferCode::Transmit(TransmitBufferState::Inactive)) as u32).get_bits(0..32))}),
-        Ok(MessageBufferCode::Receive(_)) => can.embedded_ram[start_adress].write(|w| unsafe{ w.bits(0u32.set_bits(24..28, u8::from(MessageBufferCode::Receive(ReceiveBufferCode{state: ReceiveBufferState::Inactive, busy: false})) as u32).get_bits(0..32))}),
-        Err(_) => can.embedded_ram[start_adress].write(|w| unsafe{ w.bits(0)}),
+    let start_adress = mailbox * 4;
+    match MessageBufferCode::decode(
+        can.embedded_ram[start_adress]
+            .read()
+            .bits()
+            .get_bits(24..28) as u8,
+    ) {
+        Ok(MessageBufferCode::Transmit(_)) => can.embedded_ram[start_adress].write(|w| unsafe {
+            w.bits(
+                0u32.set_bits(
+                    24..28,
+                    u8::from(MessageBufferCode::Transmit(TransmitBufferState::Inactive)) as u32,
+                )
+                .get_bits(0..32),
+            )
+        }),
+        Ok(MessageBufferCode::Receive(_)) => can.embedded_ram[start_adress].write(|w| unsafe {
+            w.bits(
+                0u32.set_bits(
+                    24..28,
+                    u8::from(MessageBufferCode::Receive(ReceiveBufferCode {
+                        state: ReceiveBufferState::Inactive,
+                        busy: false,
+                    })) as u32,
+                )
+                .get_bits(0..32),
+            )
+        }),
+        Err(_) => can.embedded_ram[start_adress].write(|w| unsafe { w.bits(0) }),
     }
 }
 
@@ -486,25 +579,49 @@ fn inactivate_mailbox(can: &can0::RegisterBlock, mailbox: usize) {
 /// If this is the case, a abort will need to occur first.
 ///
 /// If a write is succseeded the interrupt flag will also be cleared. This is so the IRQ doesn't try to access outdated data.
-fn write_mailbox(can: &can0::RegisterBlock, header: &MailboxHeader, frame: &CanFrame, mailbox: usize) -> Result<(), CanError> {
-    let start_adress = mailbox*4;
+fn write_mailbox(
+    can: &can0::RegisterBlock,
+    header: &MailboxHeader,
+    frame: &CanFrame,
+    mailbox: usize,
+) -> Result<(), CanError> {
+    let start_adress = mailbox * 4;
 
     // Check if the mailbox is ready for a write
-    let current_code = can.embedded_ram[start_adress].read().bits().get_bits(24..28) as u8;
+    let current_code = can.embedded_ram[start_adress]
+        .read()
+        .bits()
+        .get_bits(24..28) as u8;
 
     match MessageBufferCode::decode(current_code).unwrap() {
-        MessageBufferCode::Transmit(TransmitBufferState::DataRemote) => return Err(CanError::BusyMailboxWriteAttempted),
-        MessageBufferCode::Transmit(TransmitBufferState::Tanswer) => return Err(CanError::BusyMailboxWriteAttempted),
-        MessageBufferCode::Receive(ReceiveBufferCode{state: ReceiveBufferState::Empty, busy: _}) => return Err(CanError::BusyMailboxWriteAttempted),
-        MessageBufferCode::Receive(ReceiveBufferCode{state: ReceiveBufferState::Overrun, busy: _}) => return Err(CanError::BusyMailboxWriteAttempted),
-        MessageBufferCode::Receive(ReceiveBufferCode{state: ReceiveBufferState::Full, busy: _}) => return Err(CanError::BusyMailboxWriteAttempted),
-        MessageBufferCode::Receive(ReceiveBufferCode{state: ReceiveBufferState::Ranswer, busy: _}) => return Err(CanError::BusyMailboxWriteAttempted),
+        MessageBufferCode::Transmit(TransmitBufferState::DataRemote) => {
+            return Err(CanError::BusyMailboxWriteAttempted);
+        }
+        MessageBufferCode::Transmit(TransmitBufferState::Tanswer) => {
+            return Err(CanError::BusyMailboxWriteAttempted);
+        }
+        MessageBufferCode::Receive(ReceiveBufferCode {
+            state: ReceiveBufferState::Empty,
+            busy: _,
+        }) => return Err(CanError::BusyMailboxWriteAttempted),
+        MessageBufferCode::Receive(ReceiveBufferCode {
+            state: ReceiveBufferState::Overrun,
+            busy: _,
+        }) => return Err(CanError::BusyMailboxWriteAttempted),
+        MessageBufferCode::Receive(ReceiveBufferCode {
+            state: ReceiveBufferState::Full,
+            busy: _,
+        }) => return Err(CanError::BusyMailboxWriteAttempted),
+        MessageBufferCode::Receive(ReceiveBufferCode {
+            state: ReceiveBufferState::Ranswer,
+            busy: _,
+        }) => return Err(CanError::BusyMailboxWriteAttempted),
         _ => (),
     }
 
     // Clear the interrupt flag so it's clear that this transmission have not finished
-    can.iflag1.write(|w| unsafe{w.bits(1<<mailbox)} );
-    
+    can.iflag1.write(|w| unsafe { w.bits(1 << mailbox) });
+
     // 3. Write the ID word and priority
     let extended_id = match frame.id() {
         ID::BaseID(_) => false,
@@ -512,29 +629,37 @@ fn write_mailbox(can: &can0::RegisterBlock, header: &MailboxHeader, frame: &CanF
     };
 
     if extended_id {
-        unsafe {can.embedded_ram[start_adress+1].modify(|_, w| w.bits(
-            0u32
-                .set_bits(0..29, frame.id().into())
-                .set_bits(29..32, header.priority as u32)
-                .get_bits(0..32))
-        )};
+        unsafe {
+            can.embedded_ram[start_adress + 1].modify(|_, w| {
+                w.bits(
+                    0u32.set_bits(0..29, frame.id().into())
+                        .set_bits(29..32, header.priority as u32)
+                        .get_bits(0..32),
+                )
+            })
+        };
     } else {
-        unsafe {can.embedded_ram[start_adress+1].modify(|_, w| w.bits(
-            0u32
-                .set_bits(18..29, frame.id().into())
-                .set_bits(29..32, header.priority as u32)
-                .get_bits(0..32))
-        )};
+        unsafe {
+            can.embedded_ram[start_adress + 1].modify(|_, w| {
+                w.bits(
+                    0u32.set_bits(18..29, frame.id().into())
+                        .set_bits(29..32, header.priority as u32)
+                        .get_bits(0..32),
+                )
+            })
+        };
     }
 
-    
     // 4. Write the data bytes.
     let data_length = if let CanFrame::DataFrame(data_frame) = *frame {
         for index in 0..data_frame.data().len() as usize {
-            can.embedded_ram[start_adress+2 + index/4].modify(|r, w| {
+            can.embedded_ram[start_adress + 2 + index / 4].modify(|r, w| {
                 let mut bitmask = r.bits();
-                bitmask.set_bits(32-(8*(1+index%4))..(32-8*(index%4)), data_frame.data()[index] as u32);
-                unsafe{ w.bits(bitmask) }
+                bitmask.set_bits(
+                    32 - (8 * (1 + index % 4))..(32 - 8 * (index % 4)),
+                    data_frame.data()[index] as u32,
+                );
+                unsafe { w.bits(bitmask) }
             });
         }
         data_frame.data().len()
@@ -548,76 +673,95 @@ fn write_mailbox(can: &can0::RegisterBlock, header: &MailboxHeader, frame: &CanF
     };
 
     // 5. Write the DLC, Control, and CODE fields of the Control and Status word to activate the MB
-    can.embedded_ram[start_adress + 0].write(|w| unsafe{ w.bits(0u32
-                                                                .set_bit(31, false) // not CAN-FD frame
-                                                                .set_bit(29, header.error_state_indicator)
-                                                                .set_bits(24..28, u8::from(header.code.clone()) as u32)
-                                                                .set_bit(22, true) // SRR needs to be 1 to adhere to can specs
-                                                                .set_bit(21, extended_id)
-                                                                .set_bit(20, remote_frame)
-                                                                .set_bits(16..20, data_length as u32)
-                                                                .set_bits(0..15, header.time_stamp as u32)
-                                                                .get_bits(0..32))
+    can.embedded_ram[start_adress + 0].write(|w| unsafe {
+        w.bits(
+            0u32.set_bit(31, false) // not CAN-FD frame
+                .set_bit(29, header.error_state_indicator)
+                .set_bits(24..28, u8::from(header.code.clone()) as u32)
+                .set_bit(22, true) // SRR needs to be 1 to adhere to can specs
+                .set_bit(21, extended_id)
+                .set_bit(20, remote_frame)
+                .set_bits(16..20, data_length as u32)
+                .set_bits(0..15, header.time_stamp as u32)
+                .get_bits(0..32),
+        )
     });
-    
+
     Ok(())
 }
 
-
 fn read_mailbox(can: &can0::RegisterBlock, mailbox: usize) -> (MailboxHeader, CanFrame) {
-    let start_adress = mailbox*4;
+    let start_adress = mailbox * 4;
 
     // TODO: Check that mailbox is within valid range and return error (panic?) if not
-    
+
     // 1. Read control and Status word
     let mut cs = can.embedded_ram[start_adress].read().bits();
-    
+
     // 2. read untill mail box no longer busy
-    while let MessageBufferCode::Receive(code) = MessageBufferCode::decode(cs.get_bits(24..28) as u8).unwrap() {
+    while let MessageBufferCode::Receive(code) =
+        MessageBufferCode::decode(cs.get_bits(24..28) as u8).unwrap()
+    {
         if code.busy {
             cs = can.embedded_ram[start_adress].read().bits();
         } else {
-            break
+            break;
         }
     }
-        
+
     // 3. Read contents of the mailbox
     let extended_id = cs.get_bit(21);
     let id = if extended_id {
-        ID::ExtendedID(ExtendedID::new(can.embedded_ram[start_adress + 1].read().bits().get_bits(0..28)))
+        ID::ExtendedID(ExtendedID::new(
+            can.embedded_ram[start_adress + 1]
+                .read()
+                .bits()
+                .get_bits(0..28),
+        ))
     } else {
-        ID::BaseID(BaseID::new(can.embedded_ram[start_adress + 1].read().bits().get_bits(18..28) as u16))
+        ID::BaseID(BaseID::new(
+            can.embedded_ram[start_adress + 1]
+                .read()
+                .bits()
+                .get_bits(18..28) as u16,
+        ))
     };
     let dlc = cs.get_bits(16..20) as usize;
 
     let remote_frame = cs.get_bit(20);
-    
+
     let frame = if remote_frame {
         CanFrame::from(embedded_types::can::RemoteFrame::new(id))
     } else {
         let mut frame = embedded_types::can::DataFrame::new(id);
         frame.set_data_length(dlc);
         for i in 0..dlc {
-            frame.data_as_mut()[i] = can.embedded_ram[start_adress + 2 + i/4].read().bits().get_bits((32-8*(1+i%4))..32-8*(i%4)) as u8;
+            frame.data_as_mut()[i] = can.embedded_ram[start_adress + 2 + i / 4]
+                .read()
+                .bits()
+                .get_bits((32 - 8 * (1 + i % 4))..32 - 8 * (i % 4))
+                as u8;
         }
         CanFrame::from(frame)
     };
-        
 
-    let priority = can.embedded_ram[start_adress+1].read().bits().get_bits(29..32);
+    let priority = can.embedded_ram[start_adress + 1]
+        .read()
+        .bits()
+        .get_bits(29..32);
 
-    let header = MailboxHeader{
+    let header = MailboxHeader {
         error_state_indicator: cs.get_bit(29),
         code: MessageBufferCode::decode(cs.get_bits(24..28) as u8).unwrap(),
         time_stamp: cs.get_bits(0..15) as u16,
         priority: priority as u8,
     };
-   
+
     // 4. Ack proper flag
-    can.iflag1.write(|w| unsafe{w.bits(1<<mailbox)} );
+    can.iflag1.write(|w| unsafe { w.bits(1 << mailbox) });
 
     // 6. Read Free running timer to unlock mailbox
     let _time = can.timer.read();
-        
-    (header, frame.into())        
+
+    (header, frame.into())
 }

--- a/src/can.rs
+++ b/src/can.rs
@@ -3,7 +3,7 @@ use bit_field::BitField;
 use s32k144;
 use s32k144::can0;
 
-use spc;
+use crate::spc;
 
 pub use embedded_types::can::{CanFrame, ID};
 

--- a/src/console.rs
+++ b/src/console.rs
@@ -5,10 +5,10 @@
 //!  - ITM
 // TODO: implement and test ITM
 
+use crate::lpuart;
+use crate::spc;
 use embedded_types;
-use lpuart;
 use s32k144;
-use spc;
 
 impl<'p> embedded_types::io::Write for LpuartConsole<'p> {
     fn write(&mut self, buf: &[u8]) -> embedded_types::io::Result<usize> {

--- a/src/console.rs
+++ b/src/console.rs
@@ -5,20 +5,8 @@
 //!  - ITM
 // TODO: implement and test ITM
 
-use core::fmt;
-
-use cortex_m;
-
 use s32k144;
-use s32k144::LPUART1;
-use s32k144::PCC;
-use s32k144::PORTC;
-use s32k144::SCG;
-use s32k144::lpuart0;
-
 use embedded_types;
-use embedded_types::io::Write;
-
 use lpuart;
 use spc;
 

--- a/src/console.rs
+++ b/src/console.rs
@@ -5,9 +5,9 @@
 //!  - ITM
 // TODO: implement and test ITM
 
-use s32k144;
 use embedded_types;
 use lpuart;
+use s32k144;
 use spc;
 
 impl<'p> embedded_types::io::Write for LpuartConsole<'p> {
@@ -34,7 +34,7 @@ impl<'p> embedded_types::io::Read for LpuartConsole<'p> {
                     if b == byte {
                         return Ok(index);
                     }
-                },
+                }
                 Err(embedded_types::io::Error::BufferExhausted) => (),
                 Err(x) => return Err(x),
             }
@@ -49,17 +49,12 @@ pub struct LpuartConsole<'a> {
 }
 
 impl<'a> LpuartConsole<'a> {
-    pub fn init(
-        lpuart: &'a s32k144::lpuart0::RegisterBlock,
-        spc: &'a spc::Spc<'a>,
-    ) -> Self{
+    pub fn init(lpuart: &'a s32k144::lpuart0::RegisterBlock, spc: &'a spc::Spc<'a>) -> Self {
         let mut uart_config = lpuart::Config::default();
         uart_config.baudrate = 115200;
-        
-        LpuartConsole{
+
+        LpuartConsole {
             lpuart: lpuart::Lpuart::init(lpuart, spc, uart_config, 8_000_000).unwrap(),
         }
     }
 }
-
-

--- a/src/led.rs
+++ b/src/led.rs
@@ -2,10 +2,10 @@
 
 extern crate cortex_m;
 
-use s32k144;
 use pcc;
+use s32k144;
 
-pub struct RgbLed<'a>{
+pub struct RgbLed<'a> {
     ptd: &'a s32k144::ptd::RegisterBlock,
     pcc_portd: &'a pcc::PortD<'a>,
 }
@@ -20,12 +20,15 @@ impl<'a> RgbLed<'a> {
         portd: &'a s32k144::portd::RegisterBlock,
         pcc_portd: &'a pcc::PortD,
     ) -> Self {
-        ptd.pddr.write(|w| unsafe{ w.pdd().bits(ptd.pddr.read().bits() | (1<<0) | (1<<15) | (1<<16) ) } );
-        
+        ptd.pddr.write(|w| unsafe {
+            w.pdd()
+                .bits(ptd.pddr.read().bits() | (1 << 0) | (1 << 15) | (1 << 16))
+        });
+
         portd.pcr0.modify(|_, w| w.mux().bits(0b001));
         portd.pcr0.modify(|_, w| w.dse()._1());
         portd.pcr0.modify(|_, w| w.pe()._0());
-            
+
         portd.pcr15.modify(|_, w| w.mux().bits(0b001));
         portd.pcr15.modify(|_, w| w.dse()._1());
         portd.pcr15.modify(|_, w| w.pe()._0());
@@ -34,7 +37,7 @@ impl<'a> RgbLed<'a> {
         portd.pcr16.modify(|_, w| w.dse()._1());
         portd.pcr16.modify(|_, w| w.pe()._0());
 
-        RgbLed{
+        RgbLed {
             ptd: ptd,
             pcc_portd: pcc_portd,
         }
@@ -42,26 +45,33 @@ impl<'a> RgbLed<'a> {
 
     pub fn set(&self, red: bool, blue: bool, green: bool) {
         if red {
-            self.ptd.pcor.write(|w| unsafe{ w.ptco().bits(1<<Self::RED_PIN) } );
+            self.ptd
+                .pcor
+                .write(|w| unsafe { w.ptco().bits(1 << Self::RED_PIN) });
         } else {
-            self.ptd.psor.write(|w| unsafe{ w.ptso().bits(1<<Self::RED_PIN) } );
+            self.ptd
+                .psor
+                .write(|w| unsafe { w.ptso().bits(1 << Self::RED_PIN) });
         }
         if green {
-            self.ptd.pcor.write(|w| unsafe{ w.ptco().bits(1<<Self::GREEN_PIN) } );
+            self.ptd
+                .pcor
+                .write(|w| unsafe { w.ptco().bits(1 << Self::GREEN_PIN) });
         } else {
-            self.ptd.psor.write(|w| unsafe{ w.ptso().bits(1<<Self::GREEN_PIN) } );
+            self.ptd
+                .psor
+                .write(|w| unsafe { w.ptso().bits(1 << Self::GREEN_PIN) });
         }
         if blue {
-            self.ptd.pcor.write(|w| unsafe{ w.ptco().bits(1<<Self::BLUE_PIN) } );
+            self.ptd
+                .pcor
+                .write(|w| unsafe { w.ptco().bits(1 << Self::BLUE_PIN) });
         } else {
-            self.ptd.psor.write(|w| unsafe{ w.ptso().bits(1<<Self::BLUE_PIN) } );
+            self.ptd
+                .psor
+                .write(|w| unsafe { w.ptso().bits(1 << Self::BLUE_PIN) });
         }
     }
 
-    pub fn off(&self) {
-    }
-    
+    pub fn off(&self) {}
 }
-        
-
-

--- a/src/led.rs
+++ b/src/led.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code)]
+
 extern crate cortex_m;
 
 use s32k144;

--- a/src/led.rs
+++ b/src/led.rs
@@ -2,7 +2,7 @@
 
 extern crate cortex_m;
 
-use pcc;
+use crate::pcc;
 use s32k144;
 
 pub struct RgbLed<'a> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,19 +1,18 @@
 #![no_std]
 
-
-extern crate s32k144;
+extern crate bit_field;
 #[cfg_attr(feature = "itm", macro_use)]
 extern crate cortex_m;
 extern crate cortex_m_rt;
-extern crate bit_field;
 extern crate embedded_types;
+extern crate s32k144;
 
-pub mod led;
-pub mod wdog;
 pub mod can;
+pub mod led;
 pub mod lpuart;
-pub mod spc;
 pub mod pcc;
+pub mod spc;
+pub mod wdog;
 
 pub mod console;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,3 @@
-#![cfg_attr(any(feature = "panic-over-itm", feature = "panic-over-serial"), feature(core_intrinsics))]
-#![cfg_attr(any(feature = "panic-over-itm", feature = "panic-over-serial"), feature(lang_items))]
-
 #![no_std]
 
 

--- a/src/lpuart.rs
+++ b/src/lpuart.rs
@@ -1,6 +1,7 @@
+#![allow(dead_code)]
+
 use s32k144::lpuart0;
 use embedded_types::io::Error as IOError;
-use bit_field::BitField;
 
 use spc;
 

--- a/src/lpuart.rs
+++ b/src/lpuart.rs
@@ -1,7 +1,7 @@
 #![allow(dead_code)]
 
-use s32k144::lpuart0;
 use embedded_types::io::Error as IOError;
+use s32k144::lpuart0;
 
 use spc;
 
@@ -20,12 +20,12 @@ pub struct Config {
 
 impl Default for Config {
     fn default() -> Self {
-        Config{
+        Config {
             baudrate: 9600,
             data_bits: DataBits::B8,
             stop_bits: StopBits::B1,
             parity: Parity::N,
-        }            
+        }
     }
 }
 
@@ -34,7 +34,7 @@ pub enum DataBits {
     B7 = 7,
     B8 = 8,
     B9 = 9,
-    B10 = 10,        
+    B10 = 10,
 }
 
 #[derive(Copy, Clone, Debug, PartialEq)]
@@ -61,61 +61,63 @@ impl<'a> Lpuart<'a> {
         lpuart: &'a lpuart0::RegisterBlock,
         spc: &'a spc::Spc<'a>,
         config: Config,
-        source_frequency: u32
+        source_frequency: u32,
     ) -> Result<Lpuart<'a>, UartError> {
         // disable receiver and transmiter
-        lpuart.ctrl.modify(|_r, w| w
-                           .te().clear_bit()
-                           .re().clear_bit()
-        );
-        
+        lpuart
+            .ctrl
+            .modify(|_r, w| w.te().clear_bit().re().clear_bit());
+
         // TODO: check that divisor is a sensible value
         let (oversampling_ratio, divisor) = find_decent_div(source_frequency, config.baudrate)?;
         let bothedge = oversampling_ratio < 8;
-        
-        lpuart.baud.write(|w| unsafe{ w
-                                      .m10().bit(config.data_bits == DataBits::B10)
-                                      .sbns().bit(config.stop_bits == StopBits::B2)
-                                      .bothedge().bit(bothedge)
-                                      .osr().bits(oversampling_ratio-1)
-                                      .sbr().bits(divisor as u16)
+
+        lpuart.baud.write(|w| unsafe {
+            w.m10()
+                .bit(config.data_bits == DataBits::B10)
+                .sbns()
+                .bit(config.stop_bits == StopBits::B2)
+                .bothedge()
+                .bit(bothedge)
+                .osr()
+                .bits(oversampling_ratio - 1)
+                .sbr()
+                .bits(divisor as u16)
         });
 
-        lpuart.ctrl.write(|w| w
-                          .m7().bit(config.data_bits == DataBits::B7)
-                          .m().bit(config.data_bits == DataBits::B9)
-                          .pe().bit(config.parity != Parity::N)
-                          .pt().bit(config.parity == Parity::O)
-        );
+        lpuart.ctrl.write(|w| {
+            w.m7()
+                .bit(config.data_bits == DataBits::B7)
+                .m()
+                .bit(config.data_bits == DataBits::B9)
+                .pe()
+                .bit(config.parity != Parity::N)
+                .pt()
+                .bit(config.parity == Parity::O)
+        });
 
-        lpuart.fifo.write(|w| w
-                          .txfe()._1()
-                          .rxfe()._1()
-        );
-        
-        // enable receiver and transmitter 
-        lpuart.ctrl.modify(|_r, w| w
-                           .te().set_bit()
-                           .re().set_bit()
-        );
+        lpuart.fifo.write(|w| w.txfe()._1().rxfe()._1());
 
-        Ok(Lpuart{
+        // enable receiver and transmitter
+        lpuart.ctrl.modify(|_r, w| w.te().set_bit().re().set_bit());
+
+        Ok(Lpuart {
             lpuart: lpuart,
             _spc: spc,
             config: config,
         })
     }
 
-    pub fn transmit(&self, data: u8) -> Result<(), IOError>{
+    pub fn transmit(&self, data: u8) -> Result<(), IOError> {
         if self.lpuart.stat.read().tdre().is_0() {
             Err(IOError::BufferExhausted)
         } else {
-            self.lpuart.data.write(|w| unsafe{w.bits(data as u32)});
+            self.lpuart.data.write(|w| unsafe { w.bits(data as u32) });
             Ok(())
         }
     }
 
-    pub fn receive(&self) -> Result<u8, IOError>{
+    pub fn receive(&self) -> Result<u8, IOError> {
         let receive = self.lpuart.data.read();
         if receive.rxempt().bit() {
             Err(IOError::BufferExhausted)
@@ -136,28 +138,30 @@ fn find_decent_div(source: u32, baud: u32) -> Result<(u8, u16), UartError> {
 
     const DIV_MIN: u32 = 1;
     const DIV_MAX: u32 = 8191;
-    
-    let ratio = (source + baud/2)/baud;
+
+    let ratio = (source + baud / 2) / baud;
     let alternative_ratio = {
-        if ratio == source/baud {
+        if ratio == source / baud {
             ratio + 1
         } else {
             ratio - 1
         }
     };
 
-    for i in (OVERSAMPLING_MIN..OVERSAMPLING_MAX+1).rev() {
-        if ratio%i == 0 && ratio/i >= DIV_MIN && ratio/i <= DIV_MAX {
-            return Ok((i as u8, (ratio/i) as u16));
+    for i in (OVERSAMPLING_MIN..OVERSAMPLING_MAX + 1).rev() {
+        if ratio % i == 0 && ratio / i >= DIV_MIN && ratio / i <= DIV_MAX {
+            return Ok((i as u8, (ratio / i) as u16));
         }
     }
 
-    for i in (OVERSAMPLING_MIN..OVERSAMPLING_MAX+1).rev() {
-        if alternative_ratio%i == 0 && alternative_ratio/i >= DIV_MIN && alternative_ratio/i <= DIV_MAX {
-            return Ok((i as u8, (alternative_ratio/i) as u16));
+    for i in (OVERSAMPLING_MIN..OVERSAMPLING_MAX + 1).rev() {
+        if alternative_ratio % i == 0
+            && alternative_ratio / i >= DIV_MIN
+            && alternative_ratio / i <= DIV_MAX
+        {
+            return Ok((i as u8, (alternative_ratio / i) as u16));
         }
     }
 
     Err(UartError::UnsatisfiableBaud)
 }
-

--- a/src/lpuart.rs
+++ b/src/lpuart.rs
@@ -3,7 +3,7 @@
 use embedded_types::io::Error as IOError;
 use s32k144::lpuart0;
 
-use spc;
+use crate::spc;
 
 #[derive(Copy, Clone, Debug)]
 pub enum UartError {

--- a/src/panic.rs
+++ b/src/panic.rs
@@ -1,9 +1,9 @@
-use console;
+use crate::console;
+use crate::spc;
 use core::fmt;
 use cortex_m;
 use embedded_types::io::Write;
 use s32k144;
-use spc;
 
 #[cfg(feature = "panic-over-itm")]
 #[lang = "panic_fmt"]

--- a/src/panic.rs
+++ b/src/panic.rs
@@ -1,9 +1,9 @@
+use console;
 use core::fmt;
+use cortex_m;
 use embedded_types::io::Write;
 use s32k144;
-use cortex_m;
 use spc;
-use console;
 
 #[cfg(feature = "panic-over-itm")]
 #[lang = "panic_fmt"]
@@ -11,9 +11,8 @@ unsafe extern "C" fn panic_fmt(
     msg: fmt::Arguments,
     file: &'static str,
     line: u32,
-    _column: u32) -> ! {
-
-
+    _column: u32,
+) -> ! {
     cortex_m::interrupt::free(|cs| {
         let itm = ITM.borrow(cs);
         iprintln!(&itm.stim[0], "Panicked at '{}', {}:{}", msg, file, line);
@@ -33,16 +32,16 @@ unsafe extern "C" fn panic_fmt(
     msg: fmt::Arguments,
     file: &'static str,
     line: u32,
-    _column: u32) -> ! {
-
+    _column: u32,
+) -> ! {
     // This function is diverging, so if any settings have been previously made we will mess with them freely.
-    
-    let spc_config = spc::Config{
+
+    let spc_config = spc::Config {
         system_oscillator: spc::SystemOscillatorInput::Crystal(8_000_000),
         soscdiv2: spc::SystemOscillatorOutput::Div1,
-        .. Default::default()
+        ..Default::default()
     };
-    
+
     cortex_m::interrupt::free(|_cs| {
         let peripherals = s32k144::Peripherals::steal();
 
@@ -50,23 +49,24 @@ unsafe extern "C" fn panic_fmt(
         let pcc = peripherals.PCC;
         let portc = peripherals.PORTC;
         let portd = peripherals.PORTD;
-        
+
         pcc.pcc_portc.modify(|_, w| w.cgc()._1());
         pcc.pcc_portd.modify(|_, w| w.cgc()._1());
-        
+
         portc.pcr7.modify(|_, w| w.mux()._010());
         portc.pcr9.modify(|_, w| w.mux()._000());
         portd.pcr14.modify(|_, w| w.mux()._000());
-        
+
         let spc = spc::Spc::init(
             &peripherals.SCG,
             &peripherals.SMC,
             &peripherals.PMC,
-            spc_config
-        ).unwrap();
-        
+            spc_config,
+        )
+        .unwrap();
+
         let mut serial = console::LpuartConsole::init(&peripherals.LPUART1, &spc);
-        
+
         writeln!(serial, "Panicked at '{}', {}:{}", msg, file, line).unwrap();
     });
 

--- a/src/panic.rs
+++ b/src/panic.rs
@@ -1,55 +1,46 @@
-use crate::console;
-use crate::spc;
-use core::fmt;
+//! With the panic handler being `#[inline(never)]` the symbol `rust_begin_unwind` will be
+//! available to place a breakpoint on to halt when a panic is happening.
+
+use crate::{console, spc};
+use core::{
+    panic::PanicInfo,
+    sync::atomic::{self, Ordering},
+};
 use cortex_m;
 use embedded_types::io::Write;
 use s32k144;
 
 #[cfg(feature = "panic-over-itm")]
-#[lang = "panic_fmt"]
-unsafe extern "C" fn panic_fmt(
-    msg: fmt::Arguments,
-    file: &'static str,
-    line: u32,
-    _column: u32,
-) -> ! {
+#[inline(never)]
+#[panic_handler]
+fn panic(info: &PanicInfo) -> ! {
     cortex_m::interrupt::free(|cs| {
         let itm = ITM.borrow(cs);
-        iprintln!(&itm.stim[0], "Panicked at '{}', {}:{}", msg, file, line);
+        iprintln!(&itm.stim[0], "{}", info);
     });
 
-    // If running in debug mode, stop. If not, abort.
-    if cfg!(debug_assertions) {
-        loop {}
+    loop {
+        atomic::compiler_fence(Ordering::SeqCst);
     }
-
-    loop {}
 }
 
 #[cfg(feature = "panic-over-serial")]
-#[allow(dead_code)]
-unsafe extern "C" fn panic_fmt(
-    msg: fmt::Arguments,
-    file: &'static str,
-    line: u32,
-    _column: u32,
-) -> ! {
+#[inline(never)]
+#[panic_handler]
+fn panic(info: &PanicInfo) -> ! {
     // This function is diverging, so if any settings have been previously made we will mess with them freely.
-
     let spc_config = spc::Config {
         system_oscillator: spc::SystemOscillatorInput::Crystal(8_000_000),
         soscdiv2: spc::SystemOscillatorOutput::Div1,
         ..Default::default()
     };
 
-    cortex_m::interrupt::free(|_cs| {
-        let peripherals = s32k144::Peripherals::steal();
+    cortex_m::interrupt::free(|_cs| unsafe {
+        let pcc = &*s32k144::PCC::ptr();
+        let portc = &*s32k144::PORTC::ptr();
+        let portd = &*s32k144::PORTD::ptr();
 
         // turn of all other muxes than the one that muxes to the OpenSDA
-        let pcc = peripherals.PCC;
-        let portc = peripherals.PORTC;
-        let portd = peripherals.PORTD;
-
         pcc.pcc_portc.modify(|_, w| w.cgc()._1());
         pcc.pcc_portd.modify(|_, w| w.cgc()._1());
 
@@ -58,17 +49,19 @@ unsafe extern "C" fn panic_fmt(
         portd.pcr14.modify(|_, w| w.mux()._000());
 
         let spc = spc::Spc::init(
-            &peripherals.SCG,
-            &peripherals.SMC,
-            &peripherals.PMC,
+            &*s32k144::SCG::ptr(),
+            &*s32k144::SMC::ptr(),
+            &*s32k144::PMC::ptr(),
             spc_config,
         )
         .unwrap();
 
-        let mut serial = console::LpuartConsole::init(&peripherals.LPUART1, &spc);
+        let mut serial = console::LpuartConsole::init(&*s32k144::LPUART1::ptr(), &spc);
 
-        writeln!(serial, "Panicked at '{}', {}:{}", msg, file, line).unwrap();
+        writeln!(serial, "{}", info).unwrap();
     });
 
-    loop {}
+    loop {
+        atomic::compiler_fence(Ordering::SeqCst);
+    }
 }

--- a/src/pcc.rs
+++ b/src/pcc.rs
@@ -63,20 +63,18 @@ pub struct Pcc<'a> {
 
 impl<'a> Pcc<'a> {
     pub fn init(pcc: &'a s32k144::pcc::RegisterBlock) -> Self {
-        Pcc{
-            pcc: pcc,
-        }
+        Pcc { pcc: pcc }
     }
 
     pub fn enable_portc(&self) -> Result<PortC, Error> {
         let reg_value = self.pcc.pcc_portc.read();
         if reg_value.pr().is_0() {
             Err(Error::RegisterNotPresent)
-        } else if reg_value.cgc().is_1(){
+        } else if reg_value.cgc().is_1() {
             Err(Error::AlreadyEnabled)
         } else {
             self.pcc.pcc_portc.modify(|_, w| w.cgc()._1());
-            Ok(PortC{pcc: self.pcc})
+            Ok(PortC { pcc: self.pcc })
         }
     }
 
@@ -84,11 +82,11 @@ impl<'a> Pcc<'a> {
         let reg_value = self.pcc.pcc_portd.read();
         if reg_value.pr().is_0() {
             Err(Error::RegisterNotPresent)
-        } else if reg_value.cgc().is_1(){
+        } else if reg_value.cgc().is_1() {
             Err(Error::AlreadyEnabled)
         } else {
             self.pcc.pcc_portd.modify(|_, w| w.cgc()._1());
-            Ok(PortD{pcc: self.pcc})
+            Ok(PortD { pcc: self.pcc })
         }
     }
 
@@ -96,11 +94,11 @@ impl<'a> Pcc<'a> {
         let reg_value = self.pcc.pcc_porte.read();
         if reg_value.pr().is_0() {
             Err(Error::RegisterNotPresent)
-        } else if reg_value.cgc().is_1(){
+        } else if reg_value.cgc().is_1() {
             Err(Error::AlreadyEnabled)
         } else {
             self.pcc.pcc_porte.modify(|_, w| w.cgc()._1());
-            Ok(PortE{pcc: self.pcc})
+            Ok(PortE { pcc: self.pcc })
         }
     }
 
@@ -108,12 +106,14 @@ impl<'a> Pcc<'a> {
         let reg_value = self.pcc.pcc_lpuart1.read();
         if reg_value.pr().is_0() {
             Err(Error::RegisterNotPresent)
-        } else if reg_value.cgc().is_1(){
+        } else if reg_value.cgc().is_1() {
             Err(Error::AlreadyEnabled)
         } else {
-            self.pcc.pcc_lpuart1.modify(|_, w| w.pcs().bits(u8::from(source)));
+            self.pcc
+                .pcc_lpuart1
+                .modify(|_, w| w.pcs().bits(u8::from(source)));
             self.pcc.pcc_lpuart1.modify(|_, w| w.cgc()._1());
-            Ok(Lpuart1{pcc: self.pcc})
+            Ok(Lpuart1 { pcc: self.pcc })
         }
     }
 
@@ -121,11 +121,11 @@ impl<'a> Pcc<'a> {
         let reg_value = self.pcc.pcc_flex_can0.read();
         if reg_value.pr().is_0() {
             Err(Error::RegisterNotPresent)
-        } else if reg_value.cgc().is_1(){
+        } else if reg_value.cgc().is_1() {
             Err(Error::AlreadyEnabled)
         } else {
             self.pcc.pcc_flex_can0.modify(|_, w| w.cgc()._1());
-            Ok(Can0{pcc: self.pcc})
+            Ok(Can0 { pcc: self.pcc })
         }
     }
 }
@@ -159,4 +159,3 @@ impl<'a> Drop for Can0<'a> {
         self.pcc.pcc_flex_can0.reset();
     }
 }
-

--- a/src/spc.rs
+++ b/src/spc.rs
@@ -6,6 +6,8 @@
 //! - SMC (System Mode Controller)
 //! - PMC (Power Management Controller)
 
+#![allow(dead_code)]
+
 use s32k144;
 
 /// Configurations for the System Clock Generator
@@ -307,21 +309,21 @@ impl<'a> Spc<'a> {
                     },
                     RunMode::SIRC => {
                         unimplemented!("Mode::Run(RunMode::SIRC) is is not supported yet");
-                        scg.rccr.modify(|_, w| w.scs()._0010());
+                        // scg.rccr.modify(|_, w| w.scs()._0010());
                     },
                     RunMode::FIRC => {
                         scg.rccr.modify(|_, w| w.scs()._0011())
                     },
                     RunMode::SPLL => {
                         unimplemented!("Mode::Run(RunMode::SPLL) is is not supported yet");
-                        scg.rccr.modify(|_, w| w.scs()._0110())
+                        // scg.rccr.modify(|_, w| w.scs()._0110())
                     },
                 }
                 // transition into run mode
                 smc.pmctrl.modify(|_, w| w.runm()._00());
                 while smc.pmstat.read().pmstat().bits() != 0000_001 {}
             },
-            Mode::HighSpeed(mode) => {
+            Mode::HighSpeed(_mode) => {
                 // Set the dividers
                 scg.hccr.modify(|_, w| w.divcore().bits(u8::from(config.div_core)));
                 unimplemented!("High speed more is not supported yet");
@@ -386,7 +388,7 @@ impl<'a> Spc<'a> {
                     },
                 }
             },
-            Mode::HighSpeed(mode) => {
+            Mode::HighSpeed(_mode) => {
                 unimplemented!("High speed more is not supported yet");
             },
             Mode::VeryLowPower(_mode) => {

--- a/src/wdog.rs
+++ b/src/wdog.rs
@@ -96,7 +96,7 @@ impl<'a> Watchdog<'a> {
     }
 
     pub fn reset(&self) {
-        cortex_m::interrupt::free(|cs| self.register_block.cnt.write(|w| unsafe{ w.bits(0xB480_A602)}));
+        cortex_m::interrupt::free(|_cs| self.register_block.cnt.write(|w| unsafe{ w.bits(0xB480_A602)}));
     }
     
     /// pub fn configure(settings: WatchdogSettings) -> Result<(), WatchdogError> 

--- a/src/wdog.rs
+++ b/src/wdog.rs
@@ -10,18 +10,16 @@ pub enum WatchdogWindow {
 
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub struct WatchdogSettings {
-
     /// The watchdog counter is continously compared with the timeout value
     /// If the counter reaches the timeout value, the watchfog forces a
     /// reset triggering event.
     pub timeout_value: u16,
-    
+
     /// When the window mode is active the window describes the earliest time that
     /// a refresh is considered active. Refreshing earlier than the window will
     /// result in the watchdog resetting the MCU
     pub window: WatchdogWindow,
 
-    
     /// This is a fixed 256 pre-sxaling of watchfog counter reference clock.
     /// See the block diagram in the data sheet for more information
     pub prescaler: bool,
@@ -45,29 +43,29 @@ pub struct WatchdogSettings {
 
     /// enables the watchdog when the chip is in debug mode
     pub debug_enable: bool,
-    
+
     /// enables the watchdog when the chip is in wait mode
     pub wait_enable: bool,
-    
+
     /// enables the watchdog when the chip is in stop mode
     pub stop_enable: bool,
 }
 
 impl Default for WatchdogSettings {
     fn default() -> Self {
-        Self{timeout_value: 0b0000010000000000,
-             window: WatchdogWindow::Disabled,
-             prescaler: false,
-             enable: true,
-             interrupt_enable: false,
-             allow_updates: false,
-             debug_enable: false,
-             wait_enable: false,
-             stop_enable: false,
+        Self {
+            timeout_value: 0b0000010000000000,
+            window: WatchdogWindow::Disabled,
+            prescaler: false,
+            enable: true,
+            interrupt_enable: false,
+            allow_updates: false,
+            debug_enable: false,
+            wait_enable: false,
+            stop_enable: false,
         }
     }
 }
-             
 
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub enum WatchdogError {
@@ -88,7 +86,7 @@ impl<'a> Watchdog<'a> {
         wdog: &'a s32k144::wdog::RegisterBlock,
         settings: WatchdogSettings,
     ) -> Result<Self, WatchdogError> {
-        let watchdog = Watchdog{
+        let watchdog = Watchdog {
             register_block: wdog,
         };
         watchdog.configure(settings)?;
@@ -96,18 +94,21 @@ impl<'a> Watchdog<'a> {
     }
 
     pub fn reset(&self) {
-        cortex_m::interrupt::free(|_cs| self.register_block.cnt.write(|w| unsafe{ w.bits(0xB480_A602)}));
+        cortex_m::interrupt::free(|_cs| {
+            self.register_block
+                .cnt
+                .write(|w| unsafe { w.bits(0xB480_A602) })
+        });
     }
-    
-    /// pub fn configure(settings: WatchdogSettings) -> Result<(), WatchdogError> 
+
+    /// pub fn configure(settings: WatchdogSettings) -> Result<(), WatchdogError>
     ///
     /// reconfigures the watchdog timer and return Ok(()) or an error.
     pub fn configure(&self, settings: WatchdogSettings) -> Result<(), WatchdogError> {
-        
         // TODO: find good values for these constants
         const UNLOCK_TRIES: u32 = 3;
-        const UNLOCK_CHECKS: u32 = 5000; 
-            
+        const UNLOCK_CHECKS: u32 = 5000;
+
         let wdog = self.register_block;
 
         let mut unlocked_flag = false;
@@ -119,18 +120,19 @@ impl<'a> Watchdog<'a> {
                 unlocked_flag
             }
         };
-            
-        let unlock = |wdog: &s32k144::wdog::RegisterBlock| wdog.cnt.write(|w| unsafe{ w.bits(0xd928c520) });
+
+        let unlock =
+            |wdog: &s32k144::wdog::RegisterBlock| wdog.cnt.write(|w| unsafe { w.bits(0xd928c520) });
         let under_configuration = |wdog: &s32k144::wdog::RegisterBlock| wdog.cs.read().rcs().is_0();
-        
+
         if !unlocked(wdog) && under_configuration(wdog) {
             return Err(WatchdogError::ReconfigurationDisallowed);
         }
 
-        if !under_configuration(wdog) && !unlocked(wdog){
+        if !under_configuration(wdog) && !unlocked(wdog) {
             for _tries in 0..UNLOCK_TRIES {
                 unlock(wdog);
-                
+
                 let mut i = UNLOCK_CHECKS;
                 while i > 0 {
                     if unlocked(wdog) {
@@ -139,19 +141,19 @@ impl<'a> Watchdog<'a> {
                         break;
                     }
                 }
-                
+
                 if unlocked(wdog) {
                     break;
                 }
             }
         }
-        
+
         if !unlocked(wdog) {
             return Err(WatchdogError::UnlockFailed);
         }
-        
+
         self.apply_settings(settings);
-        
+
         // TODO: write some logic (acceptance test) that detects if the reconfiguration fails
         while under_configuration(wdog) {}
         Ok(())
@@ -162,25 +164,35 @@ impl<'a> Watchdog<'a> {
             WatchdogWindow::Enabled(x) => (x, true),
             WatchdogWindow::Disabled => (0x0000, false),
         };
-        
-        unsafe{ self.register_block.toval.write(|w| w.bits(settings.timeout_value as u32)); }
-        unsafe{ self.register_block.win.write(|w|  w.bits(win_value as u32)); }
-        
-        self.register_block.cs.modify(|_, w| w
-                                      .stop().bit(settings.stop_enable)
-                                      .wait().bit(settings.wait_enable)
-                                      .dbg().bit(settings.debug_enable)
-                                      .update().bit(settings.allow_updates)
-                                      .int().bit(settings.interrupt_enable)
-                                      .en().bit(settings.enable)
-                                      .pres().bit(settings.prescaler)
-                                      .cmd32en()._1()
-                                      .win().bit(win_enabled)
-        );
+
+        unsafe {
+            self.register_block
+                .toval
+                .write(|w| w.bits(settings.timeout_value as u32));
+        }
+        unsafe {
+            self.register_block.win.write(|w| w.bits(win_value as u32));
+        }
+
+        self.register_block.cs.modify(|_, w| {
+            w.stop()
+                .bit(settings.stop_enable)
+                .wait()
+                .bit(settings.wait_enable)
+                .dbg()
+                .bit(settings.debug_enable)
+                .update()
+                .bit(settings.allow_updates)
+                .int()
+                .bit(settings.interrupt_enable)
+                .en()
+                .bit(settings.enable)
+                .pres()
+                .bit(settings.prescaler)
+                .cmd32en()
+                ._1()
+                .win()
+                .bit(win_enabled)
+        });
     }
-    
-
 }
-
-
-    


### PR DESCRIPTION
This branch fixes crate/example compilation for latest stable compiler release (1.32.0). RTFM example has been updated to use RTFM v0.4.0 (also somewhat restructured).

Crate version bumped to v0.7.0.