### PR TITLE
csec: encrypt/decrypt AES128 in-place instead

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-authors = ["Kjetil Kjeka <kjetilkjeka@gmail.com>", "Tmplt <tmplt@dragons.rocks>"]
+authors = ["Kjetil Kjeka <kjetilkjeka@gmail.com>", "tmplt <tmplt@dragons.rocks>"]
 categories = ["embedded", "no-std", "hardware-support"]
 description = "Board support crate for s32k144evb"
 repository = "https://github.com/kjetilkjeka/s32k144evb.rs"
@@ -7,7 +7,7 @@ readme = "README.md"
 keywords = ["arm", "cortex-m", "s32k144", "template"]
 license = "MIT OR Apache-2.0"
 name = "s32k144evb"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2018"
 
 [dependencies]

--- a/examples/csec.rs
+++ b/examples/csec.rs
@@ -30,8 +30,7 @@ unsafe fn main() -> ! {
     };
     let _wdog = wdog::Watchdog::init(&p.WDOG, wdog_settings).unwrap();
 
-    let mut enctext: [u8; MSG_LEN] = [0; MSG_LEN];
-    let mut dectext: [u8; MSG_LEN] = [0; MSG_LEN];
+    let mut buffer: [u8; MSG_LEN] = [0; MSG_LEN];
 
     // Initialize CSEc module
     let csec = csec::CSEc::init(p.FTFC, p.CSE_PRAM);
@@ -40,11 +39,12 @@ unsafe fn main() -> ! {
 
     // Encrypt `MSG`
     let rnd_buf = csec.generate_rnd().unwrap();
-    csec.encrypt_cbc(&MSG, &rnd_buf, &mut enctext).unwrap();
+    buffer.copy_from_slice(MSG);
+    csec.encrypt_cbc(&rnd_buf, &mut buffer).unwrap();
 
     // Decrypt `MSG` and verify it
-    csec.decrypt_cbc(&enctext, &rnd_buf, &mut dectext).unwrap();
-    assert!(MSG == &dectext[..]);
+    csec.decrypt_cbc(&rnd_buf, &mut buffer).unwrap();
+    assert!(MSG == &buffer[..]);
 
     // Generate a MAC for `MSG` and verify it
     let cmac = csec.generate_mac(&MSG).unwrap();

--- a/src/csec.rs
+++ b/src/csec.rs
@@ -268,7 +268,7 @@ impl CSEc {
 
     /// Generates a vector of 128 random bits.
     /// This function must be called after `init_rng`.
-    pub fn generate_rnd(&self) -> Result<([u8; 16]), CommandResult> {
+    pub fn generate_rnd(&self) -> Result<[u8; 16], CommandResult> {
         self.write_command_header(
             Command::Rng,
             Format::Copy,

--- a/src/csec.rs
+++ b/src/csec.rs
@@ -296,7 +296,7 @@ impl CSEc {
         )
     }
 
-    /// Perform AES-128 encryption in CBC mode of the input plain text buffer.
+    /// Perform in-place AES-128 encryption in CBC mode of the input buffer.
     pub fn encrypt_cbc(
         &self,
         init_vec: &[u8; PAGE_SIZE_IN_BYTES],
@@ -305,7 +305,7 @@ impl CSEc {
         self.handle_cbc(Command::EncCbc, init_vec, buffer)
     }
 
-    /// Perform AES-128 decryption in CBC mode of the input cipher text buffer.
+    /// Perform in-place AES-128 decryption in CBC mode of the input buffer.
     pub fn decrypt_cbc(
         &self,
         init_vec: &[u8; PAGE_SIZE_IN_BYTES],

--- a/src/csec.rs
+++ b/src/csec.rs
@@ -413,10 +413,9 @@ impl CSEc {
         &self,
         command: Command,
         init_vec: &[u8; PAGE_SIZE_IN_BYTES],
-        buffer: &mut [u8]
+        buffer: &mut [u8],
     ) -> Result<(), CommandResult> {
-        if buffer.len() != buffer.len()
-            || buffer.len() % 16 != 0
+        if buffer.len() % 16 != 0
             || (buffer.len() >> BYTES_TO_PAGES_SHIFT) > u16::max_value() as usize
         {
             return Err(CommandResult::GeneralError);
@@ -457,12 +456,7 @@ impl CSEc {
 
             // Process remaining blocks, if any
             if buffer.len() - bytes != 0 {
-                process_blocks(
-                    cse,
-                    &mut buffer[bytes..],
-                    Sequence::Subsequent,
-                    command,
-                )
+                process_blocks(cse, &mut buffer[bytes..], Sequence::Subsequent, command)
             } else {
                 Ok(())
             }


### PR DESCRIPTION
Encryption is now done in-place instead; no need for an additional buffer of the same size. Additionally, all run-time asserts have been replaced with `Err` returns instead, upon fail.